### PR TITLE
fix: 修正了源代码仓库中准备数据和训练流程的许多问题，记录修改在readme中

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea
+process_data/output
+process_data/trainset
+*.ply
+*.npy

--- a/README.md
+++ b/README.md
@@ -148,3 +148,87 @@ If you find our code or paper useful, please consider citing
         booktitle={Advances in Neural Information Processing Systems (NeurIPS)},
         year={2024}
     }
+
+
+---
+
+- 安装依赖时，出现`ERROR: Could not find a version that satisfies the requirement clip==1.0 (from versions: 0.0.1, 0.1.0, 0.2.0)`，需要先行从git安装，并修改对应`environment.yml`文件中：
+
+```shell
+pip install git+https://github.com/openai/CLIP.git
+```
+
+另外，手动安装子模块：
+```shell
+pip install process_data/submodules/diff-gaussian-rasterization
+pip install process_data/submodules/simple-knn
+```
+
+最后再执行环境更新指令：
+```shell
+conda env update -f environment.yml
+```
+
+否则，会出现下载迟滞问题。
+
+---
+
+- 通过hugging face申请获得了下载ShapeNetCore数据集的权限，通过token直接把数据从hugging face下载到服务器上，避免了网盘传输或本地传输速度过慢的问题。
+
+---
+
+- 在数据准备工作中，需要安装2.9版本的blender：
+
+```shell
+cd /opt
+wget https://download.blender.org/release/Blender2.93/blender-2.93.2-linux-x64.tar.xz
+tar -xvf blender-2.93.2-linux-x64.tar.xz
+echo 'export PATH=$PATH:/opt/blender-2.93.2-linux-x64/' >> ~/.bashrc
+rm blender-2.93.2-linux-x64.tar.xz
+```
+
+---
+
+- 在headless的server中，运行render_blender，需要安装`xvfb`：
+
+```shell
+apt update && apt install xvfb -y
+```
+
+然后如下运行脚本：
+```shell
+xvfb-run -a blender --background --python render_blender.py -- --output_folder {images_path} {mesh_path}
+```
+
+---
+
+- 在编制数据集目录结构时，由于ShapeNetCore体积太大，编写了一个自动化解压脚本，筛选并解压了其中数据量较小的类别。
+
+- 在针对obj文件进行渲染时，由于每个类别中有非常多物体，例如，chair类别中有9000多个文件夹，不可能逐个执行`render_blender.py`文件进行渲染。因此，添加了针对obj文件的批处理脚本，可以一键渲染多个obj文件并保持对应路径。
+```shell
+python render_blender_batch.py -s {shapenet_folder}
+```
+
+---
+
+- 采集点云时，出现`AttributeError: 'Scene' object has no attribute 'area'.`，修改了`sample_points.py`中对应代码，手动将scene转换为单一mesh，然后再调用mesh.sample函数进行点云采样。同时，修改了点云文件保存的路径，保存在物品id对应的文件夹下，这样dataset_reader.py才能正确读取。
+
+---
+
+- 运行`train_gaussian.py`，准备GS数据时，出现`ValueError: no field of name nx'`，通过断点调试和单步执行，定位错误到文件`dataset_readers.py`的`fetchPly`函数，意思是读取的点云文件中没有法线数据，判断是`sample_points.py`中`point_cloud.export`函数没有保存法线数据。此外，还发现`fetchPly`函数读取到的点云文件中颜色值都是0。于是，不再使用`point_cloud.export`方法保存数据，转而手动构建plyfile文件，确保点云文件中包含xyz、rgb、normal等数据。
+
+---
+
+- 新建`train_gaussian_batch.py`，批量准备多个场景的数据，默认保存在`process_data/output`下，文件路径参考ShapeNetCore路径，遵循先类别后物体的双重目录结构。
+
+---
+
+- 修正了准备stage2阶段数据时，运行`python test.py -e config/stage1/ -r {num epoch}`报错的bug，具体原因为`test.py`中未加入`-r`parser参数。现在运行参数为`python test.py -e config/stage1/ -r {ckpt file_name}`。
+
+---
+
+- 修正了在stage2阶段unconditional diffusion training报错`TypeError: default_collate: batch must contain tensors, numpy arrays, numbers, dicts or lists; found <class 'NoneType'>`的bug，具体原因为在无条件输入的情况下，数据加载器`ModulationLoader`的`__getitem__`函数会返回包含None值的字典，而torch在按批次加载数据时，会把字典中同一个键的值堆叠起来，遇到None就出错了。解决方法为在`train.py`中略微修改`torch.utils.data.DataLoader`创建对象的参数，在参数`collate_fn`中传入一个经过略微修改的`default_collate`，规避了遇到None值的堆叠。
+
+---
+
+生成的npy场景如何可视化并测试指标

--- a/dataloader/modulation_loader.py
+++ b/dataloader/modulation_loader.py
@@ -31,9 +31,9 @@ class ModulationLoader(torch.utils.data.Dataset):
 
         print("data shape, dataset len: ", self.modulations[0].shape, len(self.modulations))
         #assert args.batch_size <= len(self.modulations)
-        
 
-        assert len(self.condition_paths) == len(self.modulations)
+        if self.conditional:
+            assert len(self.condition_paths) == len(self.modulations)
         
         
     def __len__(self):

--- a/diff_utils/helpers.py
+++ b/diff_utils/helpers.py
@@ -185,7 +185,8 @@ def load_model(model, optimizer, path):
 def save_code_to_conf(conf_dir):
     path = os.path.join(conf_dir, "code")
     os.makedirs(path, exist_ok=True)
-    for folder in ["utils", "models", "diff_utils", "dataloader", "metrics"]: 
+    for folder in ["utils", "models", "diff_utils", "dataloader"]:
+    # for folder in ["utils", "models", "diff_utils", "dataloader", "metrics"]:
         os.makedirs(os.path.join(path, folder), exist_ok=True)
         os.system("""cp -r ./{0}/* "{1}" """.format(folder, os.path.join(path, folder)))
 

--- a/environment.yaml
+++ b/environment.yaml
@@ -83,7 +83,7 @@ dependencies:
       - backcall==0.2.0
       - cachetools==5.2.0
       - click==8.1.3
-      - clip==1.0
+      #- clip==1.0
       - clip-score==0.1.1
       - comm==0.1.2
       - configargparse==1.5.3

--- a/models/combined_model.py
+++ b/models/combined_model.py
@@ -33,6 +33,8 @@ class CombinedModel(pl.LightningModule):
             return self.train_modulation(x)
         elif self.task == 'diffusion':
             return self.train_diffusion(x)
+        if x is None:
+            return None
         
 
     def configure_optimizers(self):
@@ -110,7 +112,8 @@ class CombinedModel(pl.LightningModule):
 
         self.train()
 
-        context = x['context'] # (B, 1024, 3) or False if unconditional 
+        context = x.get('context', None)
+        # context = x['context'] # (B, 1024, 3) or False if unconditional
         latent = x['latent'] # (B, D)
 
         # unconditional training if cond is None 

--- a/process_data/convert_data.py
+++ b/process_data/convert_data.py
@@ -1,3 +1,5 @@
+import argparse
+
 import numpy as np
 from plyfile import PlyData, PlyElement
 import torch
@@ -139,19 +141,34 @@ def process(paths):
     return 
 
 
-with open('new_area.json', 'r') as fcc_file:
-    area = json.load(fcc_file)
-
-area_json = {}
-for data in area:
-    area_json[data[0]] = data[1]
-print(len(area_json))
-
 
 if __name__ == '__main__':
 
-    save_gaussian_folder = r'path/to/your/gaussian/splatting/folder'
-    save_path = r'path/to/your/save/data/folder'
+    parser = argparse.ArgumentParser(
+        description="批量处理高斯溅射（Gaussian Splatting）训练结果，生成用于后续任务的 .npy 文件。"
+    )
+    parser.add_argument(
+        "-s", "--source",
+        type=str,
+        required=True,
+        help="包含训练结果的根目录 (例如: ./output)"
+    )
+    parser.add_argument(
+        "-t", "--target",
+        type=str,
+        default="./trainset",
+        help="用于保存处理后 .npy 文件的根目录。如果未指定，则默认将 .npy 文件保存在其原始物体目录中。"
+    )
+    parser.add_argument(
+        "-w", "--workers",
+        type=int,
+        default=20,
+        help=f"用于并行处理的进程数。默认为20。"
+    )
+    args = parser.parse_args()
+
+    save_gaussian_folder = os.path.abspath(args.source)
+    save_path = os.path.abspath(args.target)
 
     pattern = "*.ply"
     paths = []
@@ -166,6 +183,6 @@ if __name__ == '__main__':
                     i = i + 1
     print(f"{len(paths)} left to be processed!")
 
-    workers = 35
-    pool = mp.Pool(workers)
+
+    pool = mp.Pool(args.workers)
     pool.map(process, paths)

--- a/process_data/render_blender_batch.py
+++ b/process_data/render_blender_batch.py
@@ -1,0 +1,101 @@
+import argparse
+import os
+import subprocess
+import multiprocessing
+from multiprocessing import Pool
+from fnmatch import fnmatch
+
+def render_obj(arg):
+    # 接收参数
+    obj_path, relative_path, output_base = arg
+
+    # 1. 获取 OBJ 文件所在目录的相对路径 (例如: 02773838/10a.../models)
+    relative_models_dir = os.path.dirname(relative_path)
+
+    # 2. 获取 OBJ 文件 ID 目录的相对路径 (向上移动一层)
+    # 目标路径: 02773838/10a885f5971d9d4ce858db1dc3499392/
+    relative_id_dir = os.path.dirname(relative_models_dir)
+
+    # 3. 拼接得到最终的输出根目录 (Blender 脚本将把 images/ 和 transforms 放入此目录)
+    # 期望结果: /root/autodl-tmp/ShapeNetCoreImages/02773838/10a.../
+    output_folder = os.path.join(output_base, relative_id_dir)
+
+    # 确保目标输出目录存在 (必须在运行 Blender 前创建)
+    # 注意：如果目录在 worker 进程中创建，可能会有轻微的竞争条件，
+    # 但由于我们在主进程中已经跳过了已存在的目录，这里只是双重保险。
+    os.makedirs(output_folder, exist_ok=True)
+
+    print(f"Rendering {obj_path} -> Outputting to {output_folder}")
+
+    cmd = [
+        'xvfb-run', '-a', 'blender', '--background', '--python', 'render_blender.py', '--',
+        '--output_folder', output_folder,  # 传入最终的输出根路径
+        obj_path
+    ]
+
+    # 注意：在实际运行中，您可能需要将 blender 命令替换为它的完整路径 (如 /usr/local/bin/blender29)
+    try:
+        subprocess.run(cmd, check=True, capture_output=True, text=True)
+        print(f"✅ 渲染完成: {obj_path}")
+    except subprocess.CalledProcessError as e:
+        # 如果子进程（Blender/xvfb）报错，记录错误信息
+        print(f"❌ 渲染失败: {obj_path}")
+        print(f"  错误信息: {e.stderr}")
+    except FileNotFoundError:
+        print("❌ 错误: 找不到 'blender' 或 'xvfb-run' 命令。请检查您的系统PATH或使用绝对路径。")
+    # 也可以添加更多的错误处理...
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="render images from 3D models in a directory.")
+    parser.add_argument("-s", "--source", type=str, required=True,
+                        help="Path to the root directory of the ShapeNet dataset (e.g., ShapeNetCore).")
+    parser.add_argument("-t", "--target", type=str, default=None,
+                        help="Path to the target directory of the rendered images.")
+    parser.add_argument("-w", "--workers", type=int, default=20,
+                        help=f"Number of worker processes for parallel processing. Defaults to the number of CPU cores ({multiprocessing.cpu_count()}).")
+    args = parser.parse_args()
+    shapenet_folder = args.source
+    if args.target is not None:
+        output_base = args.source
+    else:
+        output_base = args.target
+    num_workers = args.workers
+
+    pattern = "*.obj"
+    tasks = []
+    skipped_count = 0
+
+    # 确保路径以斜杠结尾，方便后续处理
+    if not shapenet_folder.endswith(os.sep):
+        shapenet_folder += os.sep
+
+    for path, subdirs, files in os.walk(shapenet_folder):
+        for name in files:
+            if fnmatch(name, pattern):
+                obj_path = os.path.join(path, name)
+                # 计算相对路径
+                relative_path = obj_path.replace(shapenet_folder, '')
+
+                # 确定目标输出目录路径
+                relative_models_dir = os.path.dirname(relative_path)
+                relative_id_dir = os.path.dirname(relative_models_dir)
+                output_folder = os.path.join(output_base, relative_id_dir)
+
+                # 检查目标目录是否已存在
+                if os.path.exists(output_folder) and os.path.exists(os.path.join(output_folder, 'transforms_test.json')):
+                    # 简化处理：根据用户要求，只要目标目录存在就跳过
+                        skipped_count += 1
+                        continue  # 跳过这个OBJ文件
+
+                # 如果未跳过，则添加到任务列表
+                tasks.append((obj_path, relative_path, output_base))
+
+    print(f"--- 任务统计 ---")
+    print(f"已发现 {len(tasks) + skipped_count} 个 OBJ 文件。")
+    print(f"跳过已渲染的 {skipped_count} 个文件。")
+    print(f"将要渲染 {len(tasks)} 个文件。")
+    print(f"------------------")
+
+    pool = Pool(num_workers)
+    pool.map(render_obj, tasks)

--- a/process_data/sample_points.py
+++ b/process_data/sample_points.py
@@ -1,3 +1,4 @@
+import argparse
 import trimesh
 import numpy as np
 import os
@@ -5,36 +6,158 @@ import traceback
 from multiprocessing import Pool
 from fnmatch import fnmatch
 import multiprocessing as mp
-import json
+from plyfile import PlyData, PlyElement
+
+# def sample(arg):
+#     path, name = arg
+#     mesh = trimesh.load_mesh(os.path.join(path, name))
+#
+#     num_points = 100000
+#     points = mesh.sample(num_points)
+#
+#     point_cloud = trimesh.points.PointCloud(points)
+#
+#     save_path = os.path.join(path, 'points3d.ply')
+#     point_cloud.export(save_path)
 
 def sample(arg):
     path, name = arg
-    mesh = trimesh.load_mesh(os.path.join(path, name))
+    full_path = os.path.join(path, name)
 
-    num_points = 100000
-    points = mesh.sample(num_points)
+    # path 当前指向的是 models/ 目录
+    # 例如: /root/autodl-tmp/ShapeNetCorePart/02773838/10a885f5971d9d4ce858db1dc3499392/models
+    # target_dir 示例: /root/autodl-tmp/ShapeNetCorePart/02773838/10a885f5971d9d4ce858db1dc3499392
+    target_dir = os.path.dirname(path)
 
-    point_cloud = trimesh.points.PointCloud(points)
+    print(f"Processing: {full_path}")
+    print(f"Saving to: {target_dir}")  # 打印目标目录，方便确认
 
-    save_path = os.path.join(path, 'points3d.ply')
-    point_cloud.export(save_path)
+    try:
+        loaded_data = trimesh.load(full_path)
+        mesh = None
+
+        if isinstance(loaded_data, trimesh.Trimesh):
+            mesh = loaded_data
+
+        elif isinstance(loaded_data, trimesh.Scene):
+            merged_mesh = loaded_data.dump(concatenate=True)
+            if merged_mesh is not None:
+                mesh = merged_mesh
+                print(f"[{name}] 场景已合并为单一网格。")
+            else:
+                print(f"[{name}] 场景中无有效网格可合并，跳过。")
+                return
+        else:
+            print(f"[{name}] 加载结果类型为 {type(loaded_data)}，跳过。")
+            return
+
+        if mesh is None:
+            print(f"[{name}] 未能获取有效网格对象，跳过。")
+            return
+
+        num_points = 100000
+
+        # 确保网格有面
+        if mesh.faces.size == 0:
+            print(f"[{name}] 网格无面，无法采样，跳过。")
+            return
+
+        # 使用 Trimesh.sample() 获取位置和面索引
+        # faces_idx 是每个点采样自的面的索引
+        points, faces_idx = mesh.sample(num_points, return_index=True)
+
+        # 根据面索引获取每个采样点的法向量
+        # mesh.face_normals[faces_idx] 提供了每个采样点所在面的法向量
+        normals = mesh.face_normals[faces_idx]
+
+        # 检查 normals 数组的状态
+        print(f"[{name}] 准备导出... 检查法向量数组:")
+        print(f"   - Normals 数组的形状: {normals.shape}")
+        print(f"   - Normals 数组的数据类型: {normals.dtype}")
+        if np.isnan(normals).any():
+            print(f"   - 警告: Normals 数组中包含 NaN 值！")
+        if normals.shape[0] != num_points:
+            print(f"   - 错误: 法向量数量 ({normals.shape[0]}) 与点数 ({num_points}) 不匹配！")
+
+        num_points = points.shape[0]
+        vertex_data = np.empty(num_points, dtype=[
+            ('x', 'f4'), ('y', 'f4'), ('z', 'f4'),
+            ('nx', 'f4'), ('ny', 'f4'), ('nz', 'f4'),
+            ('red', 'u1'), ('green', 'u1'), ('blue', 'u1')  # 颜色通常是 8位无符号整数 (0-255)
+        ])
+
+        # 填充数据
+        vertex_data['x'] = points[:, 0].astype('f4')
+        vertex_data['y'] = points[:, 1].astype('f4')
+        vertex_data['z'] = points[:, 2].astype('f4')
+
+        vertex_data['nx'] = normals[:, 0].astype('f4')
+        vertex_data['ny'] = normals[:, 1].astype('f4')
+        vertex_data['nz'] = normals[:, 2].astype('f4')
+
+        # 检查 mesh 是否有可用的面部颜色
+        if hasattr(mesh.visual, 'face_colors') and len(mesh.visual.face_colors) > 0:
+            # faces_idx 是我们从 mesh.sample 得到的每个点所在面的索引
+            # 我们可以直接用它来索引面部颜色
+            print("- 网格具有面颜色，正在提取对应点的颜色。")
+            point_colors = mesh.visual.face_colors[faces_idx]
+        else:
+            # 如果没有颜色，则使用默认的灰色
+            print("- 警告: 网格无面颜色，使用默认黑色。")
+            point_colors = np.full((num_points, 4), [0, 0, 0, 255], dtype=np.uint8)
+
+        # 填充颜色数据 (注意 trimesh 颜色可能是 RGBA，我们只需要 RGB)
+        vertex_data['red'] = point_colors[:, 0]
+        vertex_data['green'] = point_colors[:, 1]
+        vertex_data['blue'] = point_colors[:, 2]
+
+        # 创建 PlyElement
+        vertex_element = PlyElement.describe(vertex_data, 'vertex')
+
+        # 构造 PlyData 并写入文件
+        save_path = os.path.join(target_dir, 'points3d.ply')
+        PlyData([vertex_element], text=True).write(save_path)
+
+        print(f"[{name}] ✅ 成功采样 {num_points} 点 (含法向量)，并使用 plyfile 手动保存到 {save_path}。")
+        print(f"   -> 文件应包含字段: {vertex_data.dtype.names}")
+
+        # # 构造包含法向量和位置的点云
+        # point_cloud = trimesh.points.PointCloud(
+        #     vertices=points,
+        #     vertex_normals=normals  # 确保这里传递的是 vertex_normals
+        # )
+        #
+        # save_path = os.path.join(target_dir, 'points3d.ply')
+        # point_cloud.export(save_path)
+        # print(f"[{name}] ✅ 成功采样 {num_points} 点 (含法向量) 并保存到 {save_path}。")
+
+    except Exception as e:
+        print(f"\n❌ ERROR processing {full_path}: {e}")
+        # traceback.print_exc()
+        pass
 
 
 if __name__ == '__main__':
-
-    shapene_folder = r'path/to/your/shapenet/folder'
-    
+    parser = argparse.ArgumentParser(description="Sample points with normals and colors from 3D models in a directory.")
+    parser.add_argument("-s", "--source", type=str, required=True,
+                        help="Path to the root directory of the ShapeNet dataset (e.g., ShapeNetCorePart).")
+    parser.add_argument("-w", "--workers", type=int, default=20,
+                        help=f"Number of worker processes for parallel processing. Defaults to the number of CPU cores ({mp.cpu_count()}).")
+    args = parser.parse_args()
+    shapenet_folder = args.source
+    num_workers = args.workers
 
     pattern = "*.obj"
-    args = []
-    for path, subdirs, files in os.walk(shapene_folder):
+    tasks = []
+    for path, subdirs, files in os.walk(shapenet_folder):
         for name in files:
             if fnmatch(name, pattern):
-                args.append((path, name))
+                # path: .../models
+                # name: model_normalized.obj
+                tasks.append((path, name))
 
-    print(f"{len(args)} left to be processed!")
+    print(f"{len(tasks)} objects left to be processed!")
 
-    workers = 35
-    pool = mp.Pool(workers)
-    pool.map(sample, args)
-    
+    with Pool(num_workers) as pool:
+        pool.map(sample, tasks)
+    print("\n🎉 全部处理完成！")

--- a/process_data/train_gaussian.py
+++ b/process_data/train_gaussian.py
@@ -24,7 +24,7 @@ from argparse import ArgumentParser, Namespace
 from arguments import ModelParams, PipelineParams, OptimizationParams
 try:
     from torch.utils.tensorboard import SummaryWriter
-    TENSORBOARD_FOUND = False
+    TENSORBOARD_FOUND = True
 except ImportError:
     TENSORBOARD_FOUND = False
 

--- a/process_data/train_gaussian_batch.py
+++ b/process_data/train_gaussian_batch.py
@@ -1,0 +1,134 @@
+import argparse
+import os
+import subprocess
+import sys
+
+def find_trainable_scenes(root_path):
+    """
+    遍历根目录，寻找所有包含 `transforms_train.json` 的子目录。
+    这些子目录被视为可训练的场景。
+    """
+    trainable_dirs = []
+    if not os.path.isdir(root_path):
+        print(f"❌ 错误: 提供的源路径 '{root_path}' 不是一个有效的目录。")
+        return trainable_dirs
+
+    print(f"正在扫描 '{root_path}' 中的可训练场景...")
+    for dirpath, _, filenames in os.walk(root_path):
+        if 'transforms_train.json' in filenames:
+            trainable_dirs.append(dirpath)
+
+    print(f"扫描完成，发现 {len(trainable_dirs)} 个可训练场景。")
+    return trainable_dirs
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="批量训练 ShapeNetCore 数据集中的所有物体。",
+        formatter_class=argparse.RawTextHelpFormatter
+    )
+    parser.add_argument(
+        "-s", "--source",
+        type=str,
+        required=True,
+        help="ShapeNetCore 数据集的根目录路径。\n"
+             "例如: /path/to/ShapeNetCoreTest (将训练所有类别)\n"
+             "或: /path/to/ShapeNetCoreTest/02773838 (将训练该类别下的所有物体)"
+    )
+    parser.add_argument(
+        "-t", "--target",
+        type=str,
+        default="./output",
+        help="存放所有训练结果的根目录。默认为 './output'。"
+    )
+    args = parser.parse_args()
+
+    source_root = os.path.abspath(args.source)
+    output_root = os.path.abspath(args.target)
+
+    # 判断输入的源路径是数据集根目录还是类别子目录，以确定计算相对路径的基准
+    source_basename = os.path.basename(source_root)
+    if source_basename.isdigit():
+        # 如果输入的是一个类别目录 (如 '02773838'),
+        # 则使用其父目录作为计算相对路径的基准
+        path_base_for_relpath = os.path.dirname(source_root)
+        print(f"检测到输入为类别目录，将使用 '{path_base_for_relpath}' 作为路径基准。")
+    else:
+        # 否则，输入路径本身就是基准
+        path_base_for_relpath = source_root
+        print(f"检测到输入为数据集根目录，将使用 '{path_base_for_relpath}' 作为路径基准。")
+
+
+    # 1. 查找所有需要训练的场景
+    scenes_to_train = find_trainable_scenes(source_root)
+
+    if not scenes_to_train:
+        print("未找到任何可训练的场景，程序退出。")
+        sys.exit(0)
+
+    # 2. 准备任务列表并过滤已完成的任务
+    tasks = []
+    skipped_count = 0
+
+    for scene_path in scenes_to_train:
+        # 使用修正后的基准路径来计算相对路径
+        relative_path = os.path.relpath(scene_path, path_base_for_relpath)
+
+        # 拼接得到最终的输出路径
+        output_path = os.path.join(output_root, relative_path)
+
+        # 检查是否已经训练过 (通过检查是否存在 point_cloud 子目录来判断)
+        if os.path.exists(os.path.join(output_path, "point_cloud")):
+            skipped_count += 1
+            continue
+
+        tasks.append({
+            "source": scene_path,
+            "target": output_path
+        })
+
+    print(f"\n--- 任务统计 ---")
+    print(f"总共发现 {len(scenes_to_train)} 个场景。")
+    print(f"已跳过 {skipped_count} 个已训练的场景。")
+    print(f"即将开始训练 {len(tasks)} 个新场景。")
+    print(f"------------------\n")
+
+    # 3. 顺序执行训练任务
+    for i, task in enumerate(tasks):
+        source_path = task["source"]
+        target_path = task["target"]
+
+        print(f"--- [{i+1}/{len(tasks)}] 开始训练 ---")
+        print(f"源路径: {source_path}")
+        print(f"目标路径: {target_path}")
+
+        os.makedirs(target_path, exist_ok=True)
+
+        command = [
+            'python',
+            'train_gaussian.py',
+            '-s', source_path,
+            '--model_path', target_path
+        ]
+
+        print(f"执行命令: {' '.join(command)}")
+
+        try:
+            process = subprocess.Popen(command, stdout=sys.stdout, stderr=sys.stderr)
+            process.wait()
+
+            if process.returncode == 0:
+                print(f"✅ 训练成功: {source_path}\n")
+            else:
+                print(f"❌ 训练失败，返回码: {process.returncode}。源路径: {source_path}\n")
+
+        except FileNotFoundError:
+            print("❌ 致命错误: 找不到 'python' 命令。请确保 Python 环境已正确配置。")
+            sys.exit(1)
+        except Exception as e:
+            print(f"❌ 训练过程中发生未知错误: {e}")
+            print(f"   源路径: {source_path}\n")
+
+    print("所有训练任务已完成！")
+
+if __name__ == '__main__':
+    main()

--- a/test.py
+++ b/test.py
@@ -76,12 +76,12 @@ def test_generation():
                 pred_color, pred_gs = model.gs_model.forward_with_plane_features(plane_feature, new_pc)
                 gaussian = torch.zeros(new_pc.shape[1], 59).cpu()
                 gaussian[:,:3] = new_pc[0]
-                gaussian[:,3:51]
                 gaussian[:,3:51] = pred_color[0]
                 gaussian[:,51] = 2.9444
                 gaussian[:,52:55] = 0.9 * torch.log(pred_gs[0,:,0:3])
                 gaussian[:,55:59] = pred_gs[0,:,3:7]
-                convert(gaussian.detach().cpu().numpy(), f"./generate/gaussian_{idx}.ply")
+                save_path = os.path.join(args.exp_dir, f"gaussian_{idx}.ply")
+                convert(gaussian.detach().cpu().numpy(), save_path)
                 idx = idx + 1
 
 if __name__ == "__main__":
@@ -99,6 +99,11 @@ if __name__ == "__main__":
     arg_parser.add_argument("--epoches", default=100, type=int, help='number of epoches to generate and reconstruct')
 
     arg_parser.add_argument("--filter", default=False, help='whether to filter when sampling conditionally')
+
+    arg_parser.add_argument(
+        "--resume", "-r", default=None,
+        help="continue from previous saved logs, integer value, 'last', or 'finetune'",
+    )
 
     args = arg_parser.parse_args()
     specs = json.load(open(os.path.join(args.exp_dir, "specs.json")))


### PR DESCRIPTION
具体如下：

---

- 安装依赖时，出现`ERROR: Could not find a version that satisfies the requirement clip==1.0 (from versions: 0.0.1, 0.1.0, 0.2.0)`，需要先行从git安装，并修改对应`environment.yml`文件中：

```shell
pip install git+https://github.com/openai/CLIP.git
```

另外，手动安装子模块：
```shell
pip install process_data/submodules/diff-gaussian-rasterization
pip install process_data/submodules/simple-knn
```

最后再执行环境更新指令：
```shell
conda env update -f environment.yaml
```

否则，会出现下载迟滞问题。

---

- 在数据准备工作中，需要安装2.9版本的blender：

```shell
cd /opt
wget https://download.blender.org/release/Blender2.93/blender-2.93.2-linux-x64.tar.xz
tar -xvf blender-2.93.2-linux-x64.tar.xz
echo 'export PATH=$PATH:/opt/blender-2.93.2-linux-x64/' >> ~/.bashrc
rm blender-2.93.2-linux-x64.tar.xz
```

---

- 在headless的server中，运行render_blender，需要安装`xvfb`：

```shell
apt update && apt install xvfb -y
```

然后如下运行脚本：
```shell
xvfb-run -a blender --background --python render_blender.py -- --output_folder {images_path} {mesh_path}
```

---

- 在针对obj文件进行渲染时，由于每个类别中有非常多物体，例如，chair类别中有9000多个文件夹，不可能逐个执行`render_blender.py`文件进行渲染。因此，添加了针对obj文件的批处理脚本，可以一键渲染多个obj文件并保持对应路径。
```shell
python render_blender_batch.py -s {shapenet_folder}
```

---

- 采集点云时，出现`AttributeError: 'Scene' object has no attribute 'area'.`，修改了`sample_points.py`中对应代码，手动将scene转换为单一mesh，然后再调用`mesh.sample`函数进行点云采样。同时，修改了点云文件保存的路径，保存在物品id对应的文件夹下，这样`dataset_reader.py`才能正确读取。

---

- 运行`train_gaussian.py`，准备GS数据时，出现`ValueError: no field of name nx'`，通过断点调试和单步执行，定位错误到文件`dataset_readers.py`的`fetchPly`函数，意思是读取的点云文件中没有法线数据，判断是`sample_points.py`中`point_cloud.export`函数没有保存法线数据。此外，还发现`fetchPly`函数读取到的点云文件中颜色值都是0。于是，不再使用`point_cloud.export`方法保存数据，转而手动构建plyfile文件，确保点云文件中包含xyz、rgb、normal等数据。

---

- 新建`train_gaussian_batch.py`，批量准备多个场景的数据，默认保存在`process_data/output`下，文件路径参考ShapeNetCore路径，遵循先类别后物体的双重目录结构。

---

- 修正了准备stage2阶段数据时，运行`python test.py -e config/stage1/ -r {num epoch}`报错的bug，具体原因为`test.py`中未加入`-r`parser参数。现在运行参数为`python test.py -e config/stage1/ -r {ckpt_fileName}`。

---

- 修正了在stage2阶段unconditional diffusion training报错`TypeError: default_collate: batch must contain tensors, numpy arrays, numbers, dicts or lists; found <class 'NoneType'>`的bug，具体原因为在无条件输入的情况下，数据加载器`ModulationLoader`的`__getitem__`函数会返回包含None值的字典，而torch在按批次加载数据时，会把字典中同一个键的值堆叠起来，遇到None就出错了。解决方法为在`train.py`中略微修改`torch.utils.data.DataLoader`创建对象的参数，在参数`collate_fn`中传入一个经过略微修改的`default_collate`，规避了遇到None值的堆叠。